### PR TITLE
Fix for non-English speaking users

### DIFF
--- a/start.py
+++ b/start.py
@@ -52,7 +52,7 @@ if not authData["steamLoginSecure"]:
 def generateCookies():
     global authData
     try:
-        cookies = dict(sessionid = authData["sessionid"], steamLoginSecure = authData["steamLoginSecure"], steamparental = authData["steamparental"])
+        cookies = dict(sessionid = authData["sessionid"], steamLoginSecure = authData["steamLoginSecure"], steamparental = authData["steamparental"], Steam_Language = "english")
     except:
         logging.warning(Fore.RED + "Error setting cookies" + Fore.RESET)
         input("Press Enter to continue...")


### PR DESCRIPTION
This patch sets the `Steam_Language` cookie to `english` in order to force Steam to use English, even if the user has set Steam to use another language.

Without this patch:
```
[ 04/14/2024 01:58:42 AM ] WELCOME TO IDLE MASTER - v2.1
[ 04/14/2024 01:58:42 AM ] Finding games that have card drops remaining
[ 04/14/2024 01:58:44 AM ] Reading badge page, please wait
[ 04/14/2024 01:58:44 AM ] Getting card values, please wait...
[ 04/14/2024 01:58:44 AM ] Idle Master needs to idle 0 games
[ 04/14/2024 01:58:44 AM ] Successfully completed idling process
[ 04/14/2024 01:58:44 AM ] 0 games skipped
```

With this patch:
```
[ 04/14/2024 01:59:17 AM ] WELCOME TO IDLE MASTER - v2.1
[ 04/14/2024 01:59:17 AM ] Finding games that have card drops remaining
[ 04/14/2024 01:59:18 AM ] Reading badge page, please wait
[ 04/14/2024 01:59:18 AM ] Getting card values, please wait...
[...]
[ 04/14/2024 01:59:43 AM ] Idle Master needs to idle 61 games
```