### PR TITLE
[Fixed] Stacktrace on SIGINT during SIGINT handling

### DIFF
--- a/start.py
+++ b/start.py
@@ -337,7 +337,10 @@ for appID, drops, value in games:
                 print("    s = Skip game")
                 print("    b = Blacklist game")
 
-                ans = input("Select option ... ")
+                try:
+                    ans = input("Select option ... ")
+                except KeyboardInterrupt:
+                    ans = "q"
                 if ans == "q" or ans == "Q": 
                     logging.warning(Fore.RED + "User quit script" + Fore.RESET)
                     sys.exit()


### PR DESCRIPTION
When SIGINTing while the program is already handling the SIGINT, the program spews out the stacktrace while waiting for input. Of course, SIGINTing at that point in the control flow, it can be interpreted as simply wanting to exit the program, so that is what is done.